### PR TITLE
Cast the error to string to see it

### DIFF
--- a/testsuites/CBLTester/capella_support_sgw/capella_appService_test/conftest.py
+++ b/testsuites/CBLTester/capella_support_sgw/capella_appService_test/conftest.py
@@ -199,7 +199,7 @@ def params_from_base_suite_setup(request):
         target_public_url = capellaSetup['publicURL'].replace("wss", "https")
         target_blip_url = capellaSetup['publicURL']
     except Exception as err:
-        log_error("Failed to setup appService due to: " + err)
+        log_error("Failed to setup appService due to: " + str(err))
 
     yield {
         "liteserv_platform": liteserv_platform,


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Fix the casting of the error object, to be able to print it. 
-

